### PR TITLE
Fix: Assign read preference to the secondary by default 

### DIFF
--- a/mongo/readpref_test.go
+++ b/mongo/readpref_test.go
@@ -1,0 +1,49 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+func TestResolveReadPrefUsesConfiguredForFind(t *testing.T) {
+	secondary, err := readpref.New(readpref.SecondaryMode)
+	require.NoError(t, err)
+
+	m := Mongo{defaultReadPref: secondary}
+
+	rp := m.resolveReadPref(nil, false, Find, &opMsg{})
+	require.Equal(t, readpref.SecondaryMode, rp.Mode())
+}
+
+func TestResolveReadPrefPrefersPrimaryForWrites(t *testing.T) {
+	secondary, err := readpref.New(readpref.SecondaryMode)
+	require.NoError(t, err)
+
+	m := Mongo{defaultReadPref: secondary}
+
+	rp := m.resolveReadPref(nil, false, Insert, &opMsg{})
+	require.Equal(t, readpref.PrimaryMode, rp.Mode())
+}
+
+func TestResolveReadPrefHonorsProvidedPreference(t *testing.T) {
+	secondary, err := readpref.New(readpref.SecondaryMode)
+	require.NoError(t, err)
+	m := Mongo{defaultReadPref: secondary}
+
+	nearest, err := readpref.New(readpref.NearestMode)
+	require.NoError(t, err)
+
+	rp := m.resolveReadPref(nearest, true, Find, &opMsg{})
+	require.Same(t, nearest, rp)
+}
+
+func TestResolveReadPrefSupportsLegacyQueries(t *testing.T) {
+	secondary, err := readpref.New(readpref.SecondaryMode)
+	require.NoError(t, err)
+	m := Mongo{defaultReadPref: secondary}
+
+	rp := m.resolveReadPref(nil, false, Unknown, &opQuery{})
+	require.Equal(t, readpref.SecondaryMode, rp.Mode())
+}


### PR DESCRIPTION
## How It Works

- When mongobetween starts, it builds a MongoDB client per configured upstream address.
- If a read preference is already provided in the upstream URI, mongobetween uses it.
- If no preference is specified, mongobetween falls back to `secondary` for all operations that are safe to read from a secondary.
- Explicit read preferences sent by the client at runtime still win.
- Write operations and commands that must target the primary continue to do so.

## Configuring the Connection String

Set the desired read preference directly on the mongobetween upstream URI:

```
localhost:27017=mongodb://user:pass@mongo1/?replicaSet=rs0&readPreference=secondary&authSource=admin
```

If you omit `readPreference`, mongobetween automatically applies `secondary` for eligible read operations. You can override this per request from clients (for example by including `$readPreference` in `find` commands) when needed.